### PR TITLE
fix: add padding to button elements for improved touch target size

### DIFF
--- a/src/components/base/dialog/BaseDialog.vue
+++ b/src/components/base/dialog/BaseDialog.vue
@@ -72,14 +72,14 @@ const onCloseDialog = (): void => {
               class="tot-pad-m tot-gap-m flex flex-col overflow-hidden transition-all duration-300 ease-in-out transform border-2 rounded-lg shadow-lg shadow-sb-secondary-200 border-sb-secondary-200 bg-sb-main"
             >
               <div
-                class="flex justify-between overflow-hidden cursor-default shrink-0 tot-gap-m transition-all duration-300 ease-in-out"
+                class="flex justify-between cursor-default shrink-0 tot-gap-m transition-all duration-300 ease-in-out"
               >
                 <div
                   :class="{
                     'text-left': props.headerOrientation === 'left',
                     'text-center': props.headerOrientation === 'center',
                   }"
-                  class="flex-1 overflow-x-hidden"
+                  class="flex-1"
                 >
                   <h3
                     v-show="props.dialogTitle"
@@ -90,7 +90,7 @@ const onCloseDialog = (): void => {
                   </h3>
                 </div>
                 <BaseButton
-                  class="text-white border border-transparent rounded-md w-fit h-fit hover:rotate-90 focus-visible:border-white"
+                  class="text-white border border-white rounded-md w-fit h-fit hover:rotate-90 focus-visible:ring-2 ring-white p-1"
                   :aria-label="`close ${props.dialogTitle} modal`"
                   variant="custom"
                   size="custom"

--- a/src/components/layouts/header/AppHeader.vue
+++ b/src/components/layouts/header/AppHeader.vue
@@ -199,7 +199,7 @@ const handleMQ = (e: MediaQueryListEvent): void => {
         <!-- Mobile toggle button (visible < lg) -->
         <button
           type="button"
-          class="lg:hidden inline-flex items-center justify-center rounded-md cursor-pointer"
+          class="lg:hidden inline-flex items-center justify-center rounded-md cursor-pointer p-1"
           aria-controls="mobile-nav"
           aria-expanded="false"
           aria-label="Toggle navigation"

--- a/src/pages/skills-page/components/skill-card/SkillCard.vue
+++ b/src/pages/skills-page/components/skill-card/SkillCard.vue
@@ -102,7 +102,7 @@ const goPrevious = (): void => {
         class="absolute p-2.5 sm:p-3 md:p-3 lg:p-4 top-0 flex flex-col w-full h-full transition-all duration-300 ease-in-out z-[200] bg-sb-secondary-300"
       >
         <BaseButton
-          class="absolute top-3.5 right-2.5 sm:top-4 sm:right-3 md:top-4 md:rigt-3 lg:top-5 lg:right-4 text-white border border-transparent rounded-md w-fit h-fit hover:rotate-90 focus-visible:border-white"
+          class="absolute top-3.5 right-2.5 sm:top-4 sm:right-3 md:top-4 md:right-3 lg:top-5 lg:right-4 text-white border border-white rounded-md w-fit h-fit hover:rotate-90 focus-visible:ring-2 ring-white p-1"
           size="custom"
           variant="custom"
           :aria-label="`close ${props.skill.name} details panel`"


### PR DESCRIPTION
This pull request focuses on improving the UI consistency and accessibility of close and toggle buttons across several components by refining their styling and interactive states. The main changes involve standardizing border colors, adding focus-visible outlines, and fixing minor layout issues.

**Button and Dialog UI Consistency:**

* Updated close buttons in `BaseDialog.vue` and `SkillCard.vue` to use a white border, add a visible focus ring for accessibility, and include consistent padding. [[1]](diffhunk://#diff-cc523262a8efbb03c0a6a9d6ddf525deb30c3a201f7132e59825659c95866df8L93-R93) [[2]](diffhunk://#diff-17a70816935ff464db4ea14d0aa6e1ef81490f8afe9b27b9b3f29b453a1ed719L105-R105)
* Removed unnecessary `overflow-hidden` classes from dialog header elements in `BaseDialog.vue` for cleaner layout.

**Header Layout Improvements:**

* Added padding to the mobile navigation toggle button in `AppHeader.vue` to improve touch target size and alignment.

**Bug Fixes:**

* Fixed a typo in the `SkillCard.vue` close button class name (`md:rigt-3` → `md:right-3`).